### PR TITLE
Fix incorrect saving of iter-0 checkpoint

### DIFF
--- a/megatron/training/checkpointing.py
+++ b/megatron/training/checkpointing.py
@@ -297,6 +297,9 @@ def save_checkpoint(iteration, model, optimizer, opt_param_scheduler,
             print(f"rank={torch_distributed.get_rank()} failed to create directory for distributed optimizer checkpoint: {e}")
             exit(1)
 
+        # NOTE(odashi):
+        # We don't save the initial optimizer state since all the values are predictable
+        # and the inner structure of the object is not initialized at this moment.
         if iteration != 0:
             optimizer.save_parameter_state(optim_checkpoint_name)
 

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -337,11 +337,6 @@ def pretrain(train_valid_test_dataset_provider,
 
         iteration = 0
 
-        # NOTE(odashi): we also save the initial checkpoint
-        if args.save:
-            save_checkpoint(iteration, model, optimizer, opt_param_scheduler,
-                            args.num_floating_point_operations_so_far)
-
         if args.do_train and args.train_iters > 0:
             iteration, num_floating_point_operations_so_far = train(
                 forward_step_func,
@@ -1068,6 +1063,11 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
         })
 
     num_floating_point_operations_so_far = args.num_floating_point_operations_so_far
+
+    # NOTE(odashi): we also save the initial checkpoint
+    if args.save and iteration == 0:
+        save_checkpoint_and_time(iteration, model, optimizer, opt_param_scheduler,
+                                 num_floating_point_operations_so_far)
 
     # Setup some training config params
     config.grad_scale_func = optimizer.scale_loss


### PR DESCRIPTION
This PR fixes a bug that accidentally saves a checkpoint with name `iter_0000000` with incorrect values upon resuming the training process.
