### PR TITLE
Add script to check file size of checkpoint on gcp cloud

### DIFF
--- a/scripts/gcp/check_cloud_filesize.sh
+++ b/scripts/gcp/check_cloud_filesize.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+ 
+LOCAL_CKPT_DIR="/lustre/checkpoints/llama-2-172b-exp2/tp4-pp16-cp1"
+CLOUD_CKPT_DIR="gs://llama2-172b-checkpoint-exp2"
+
+
+for iter in $(ls ${LOCAL_CKPT_DIR} | grep iter_); do
+	local_size=$(du -scb ${LOCAL_CKPT_DIR}/${iter}/*/*.pt | tail -n1 | cut -f1)
+	cloud_size=$(gsutil du -sc "${CLOUD_CKPT_DIR}/${iter}" | tail -n1 | awk '{print $1}')
+
+	echo "${iter} Local size:${local_size} Cloud size:${cloud_size}"
+
+	if [ "$local_size" -ne "$cloud_size" ]; then
+		echo "Error: ${iter} file sizes are different."
+	fi
+done
+


### PR DESCRIPTION
Compare checkpoint file sizes between cloud storage and local storage.

```bash
$bash scripts/gcp/check_cloud_filesize.sh
iter_0001000 Local size:2413716843904 Cloud size:2413716843904
iter_0002000 Local size:2413716844160 Cloud size:2413716844160
iter_0003000 Local size:2413716844160 Cloud size:2413716844160
iter_0004000 Local size:2413716844160 Cloud size:2413716844160
iter_0005000 Local size:2413716844160 Cloud size:2413716844160
iter_0006000 Local size:2413716844160 Cloud size:2413716844160
iter_0007000 Local size:2413716844160 Cloud size:2413716844160
iter_0008000 Local size:2413716844160 Cloud size:2413716844160
iter_0009000 Local size:2413716844160 Cloud size:2413716844160
iter_0010000 Local size:2413716844160 Cloud size:2413716844160
iter_0011000 Local size:2413716844160 Cloud size:2413716844160
iter_0012000 Local size:2413716844160 Cloud size:2413716844160
iter_0013000 Local size:2413716844160 Cloud size:2413716844160
iter_0014000 Local size:2413716844160 Cloud size:2413716844160
```