### PR TITLE
Add --force-stop-iter option

### DIFF
--- a/megatron/training/arguments.py
+++ b/megatron/training/arguments.py
@@ -1688,5 +1688,7 @@ def _add_experimental_args(parser):
                        '`transformer_block.py`, or `transformer_layer.py`')
     group.add_argument('--yaml-cfg', type=str, default=None,
                        help = 'Config file to add additional arguments')
+    group.add_argument('--force-stop-iter', type=int, default=None,
+                       help="Stop training process at this iteration regardless of any other configs.")
 
     return parser

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1150,7 +1150,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                 'validation_iterations_time_msecs_avg': validation_iterations_time_msecs_avg
             })
 
-    while iteration < args.train_iters:
+    while iteration < args.train_iters and iteration < args.force_stop_iter:
         if (
             # train_data_iterator is not None
             args.skip_train_iteration_range is not None

--- a/megatron/training/training.py
+++ b/megatron/training/training.py
@@ -1150,7 +1150,7 @@ def train(forward_step_func, model, optimizer, opt_param_scheduler,
                 'validation_iterations_time_msecs_avg': validation_iterations_time_msecs_avg
             })
 
-    while iteration < args.train_iters and iteration < args.force_stop_iter:
+    while iteration < args.train_iters and (args.force_stop_iter is None or iteration < args.force_stop_iter):
         if (
             # train_data_iterator is not None
             args.skip_train_iteration_range is not None


### PR DESCRIPTION
This branch adds `--force-stop-iter` option. This option specifies the iteration number to stop the training process whenever the process reaches the specified step regardless of any other options.

I decided to add this option because other options to specify training steps (e.g., `--train-iters`) are often used by other part of the program and changing them accidentally causes unwanted side-effects.